### PR TITLE
Jakarta data persistence integration to GlassFish (no 1)

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver-osgi-bundle/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver-osgi-bundle/pom.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~
+~  Copyright (c) 2025 Contributors to the Eclipse Foundation
+~   All rights reserved. This program and the accompanying materials
+~   are made available under the terms of the Eclipse Public License v1.0
+~   and Apache License v2.0 which accompanies this distribution.
+~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+~
+~   You may elect to redistribute this code under either of these licenses.
+~
+~   Contributors:
+~
+~   Ondro Mihalyi
+~   Arjan Tijms
+~
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.jnosql.mapping</groupId>
+        <artifactId>jnosql-jakarta-persistence-parent</artifactId>
+        <version>1.1.8-SNAPSHOT</version>
+    </parent>
+
+    <groupId>ee.omnifish</groupId>
+    <artifactId>jnosql-jakarta-persistence-osgi-bundle</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Eclipse JNoSQL Jakarta Persistence Driver OSGi bundle</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jnosql-jakarta-persistence</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.communication</groupId>
+                    <artifactId>jnosql-communication-query</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.6.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+
+            <!-- Check licenses of dependencies -->
+            <plugin>
+                <groupId>org.eclipse.dash</groupId>
+                <artifactId>license-tool-plugin</artifactId>
+            </plugin>
+
+            <!-- Generate a "consumer pom" for the generated jar -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+
+            <!-- Creates the OSGi MANIFEST.MF file -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <_noimportjava>true</_noimportjava>
+                        <_runee>JavaSE-17</_runee>
+                        <!-- <Automatic-Module-Name>org.eclipse.jnosql.jakartapersistence</Automatic-Module-Name> -->
+                        <Extension-Name>org.eclipse.jnosql.jakartapersistence</Extension-Name>
+
+                        <Bundle-SymbolicName>org.eclipse.jnosql.jakartapersistence</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Bundle-Name>Jakarta Data Implementation ${project.version}</Bundle-Name>
+                        <Bundle-Description>Eclipse Jakarta Data Implementation (jakarta.data/1.0) ${project.version}</Bundle-Description>
+
+                        <Specification-Title>Jakarta Data</Specification-Title>
+                        <Specification-Version>1.0</Specification-Version>
+                        <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
+
+                        <Implementation-Title>JNoSQL Jakarta Persistence</Implementation-Title>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                        <Implementation-Vendor>Eclipse</Implementation-Vendor>
+                        <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
+
+                        <Import-Package>
+                            !org.eclipse.jnosql.mapping.reflection.*,
+                            *
+                        </Import-Package>
+                        <!-- TODO: import antlr runtime instead of bundling it -->
+                        <Embed-Dependency>
+                            !jakarta.data-api.*,
+                            !jakarta.persistence-api.*,
+                            !jnosql-mapping-reflection,
+                            !classgraph,
+<!--                            jnosql-jakarta-persistence;inline=true,-->
+                            *;scope=compile|runtime
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Export-Package>org.eclipse.jnosql.jakartapersistence.communication,*</Export-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <profiles>
+         <profile>
+            <id>release</id>
+            
+            <properties>
+                <altDeploymentRepository>central::https://central.sonatype.com/repository/maven-snapshots</altDeploymentRepository>
+                <altSnapshotDeploymentRepository>central::https://central.sonatype.com/repository/maven-snapshots</altSnapshotDeploymentRepository>
+                <deploy.skip>false</deploy.skip>
+            </properties>
+            
+            <build>
+                <plugins>
+                    <!-- Signing with GPG is a requirement for a release deployment to Maven central. -->
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.7.0</version>
+                        <extensions>false</extensions>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver-osgi-bundle/src/main/resources/META-INF/services/org.eclipse.jnosql.mapping.core.repository.RepositoryReturn
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver-osgi-bundle/src/main/resources/META-INF/services/org.eclipse.jnosql.mapping.core.repository.RepositoryReturn
@@ -1,0 +1,9 @@
+org.eclipse.jnosql.mapping.core.repository.returns.InstanceRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.ListRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.OptionalRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.PageRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.QueueRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.SetRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.SortedSetRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.StreamRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.ArrayRepositoryReturn

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~
-  ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
-  ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
-  ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
-  ~
-  ~   You may elect to redistribute this code under either of these licenses.
-  ~
-  ~   Contributors:
-  ~
-  ~   Ondro Mihalyi
-  ~   Arjan Tijms
-  ~
-  -->
+~
+~  Copyright (c) 2024 Contributors to the Eclipse Foundation
+~   All rights reserved. This program and the accompanying materials
+~   are made available under the terms of the Eclipse Public License v1.0
+~   and Apache License v2.0 which accompanies this distribution.
+~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+~
+~   You may elect to redistribute this code under either of these licenses.
+~
+~   Contributors:
+~
+~   Ondro Mihalyi
+~   Arjan Tijms
+~
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -65,7 +65,7 @@
                     <artifactId>jnosql-communication-query</artifactId>
                 </exclusion>
                 <!-- <exclusion> <groupId>org.eclipse.jnosql.mapping</groupId> 
-                    <artifactId>jnosql-mapping-reflection</artifactId> </exclusion> -->
+                <artifactId>jnosql-mapping-reflection</artifactId> </exclusion> -->
             </exclusions>
         </dependency>
         <dependency>
@@ -208,62 +208,6 @@
                 </executions>
             </plugin>
 
-            <!-- Creates the OSGi MANIFEST.MF file -->
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>6.0.0</version>
-                <configuration>
-                    <instructions>
-                        <_noimportjava>true</_noimportjava>
-                        <_runee>JavaSE-17</_runee>
-                        <!-- <Automatic-Module-Name>org.eclipse.jnosql.jakartapersistence</Automatic-Module-Name> -->
-                        <Extension-Name>org.eclipse.jnosql.jakartapersistence</Extension-Name>
-
-                        <Bundle-SymbolicName>org.eclipse.jnosql.jakartapersistence</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <Bundle-Name>Jakarta Data Implementation ${project.version}</Bundle-Name>
-                        <Bundle-Description>Eclipse Jakarta Data Implementation (jakarta.data/1.0) ${project.version}</Bundle-Description>
-
-                        <Specification-Title>Jakarta Data</Specification-Title>
-                        <Specification-Version>1.0</Specification-Version>
-                        <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
-
-                        <Implementation-Title>JNoSQL Jakarta Persistence</Implementation-Title>
-                        <Implementation-Version>${project.version}</Implementation-Version>
-                        <Implementation-Vendor>Eclipse</Implementation-Vendor>
-                        <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
-
-                        <Import-Package>
-                            jakarta.enterprise.inject.spi.configurator, ${osgi.imports}
-                        </Import-Package>
-                        <Export-Package>
-                            org.eclipse.jnosql.jakartapersistence.*, ${osgi.exports}
-                        </Export-Package>
-                    </instructions>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-                <configuration>
-                    <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                </configuration>
-            </plugin>
-
             <!-- Check licenses of dependencies -->
             <plugin>
                 <groupId>org.eclipse.dash</groupId>
@@ -320,6 +264,68 @@
     
             <build>
                 <plugins>
+                    <!-- Creates the OSGi MANIFEST.MF file -->
+                    <plugin>
+                        <groupId>org.apache.felix</groupId>
+                        <artifactId>maven-bundle-plugin</artifactId>
+                        <version>6.0.0</version>
+                        <configuration>
+                            <instructions>
+                                <_noimportjava>true</_noimportjava>
+                                <_runee>JavaSE-17</_runee>
+                                <!-- <Automatic-Module-Name>org.eclipse.jnosql.jakartapersistence</Automatic-Module-Name> -->
+                                <Extension-Name>org.eclipse.jnosql.jakartapersistence</Extension-Name>
+
+                                <Bundle-SymbolicName>org.eclipse.jnosql.jakartapersistence</Bundle-SymbolicName>
+                                <Bundle-Version>${project.version}</Bundle-Version>
+                                <Bundle-Name>Jakarta Data Implementation ${project.version}</Bundle-Name>
+                                <Bundle-Description>Eclipse Jakarta Data Implementation (jakarta.data/1.0) ${project.version}</Bundle-Description>
+
+                                <Specification-Title>Jakarta Data</Specification-Title>
+                                <Specification-Version>1.0</Specification-Version>
+                                <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
+
+                                <Implementation-Title>JNoSQL Jakarta Persistence</Implementation-Title>
+                                <Implementation-Version>${project.version}</Implementation-Version>
+                                <Implementation-Vendor>Eclipse</Implementation-Vendor>
+                                <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
+
+                                <Import-Package>
+                                    jakarta.enterprise.inject.spi.configurator, !org.antlr.*, ${osgi.imports}
+                                </Import-Package>
+                                <Embed-Dependency>org.antlr:*,
+                                                    org.eclipse.jnosql.mapping:*,
+                                                    org.eclipse.jnosql.communication:*,
+                                                    jakarta.nosql:*
+                                </Embed-Dependency>
+                                <Export-Package>
+                                    org.eclipse.jnosql.jakartapersistence.*, org.eclipse.jnosql.communication.*,
+                                    org.eclipse.jnosql.mapping.core.spi.*, ${osgi.exports}
+                                </Export-Package>
+                            </instructions>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>bundle-manifest</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>manifest</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.4.2</version>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </plugin>
+
                     <plugin>
                         <artifactId>maven-shade-plugin</artifactId>
                         <version>3.6.0</version>
@@ -338,6 +344,7 @@
                                             <include>org.eclipse.jnosql.mapping:*:*</include>
                                             <include>org.eclipse.jnosql.communication:*:*</include>
                                             <include>jakarta.nosql:*:*</include>
+                                            <include>org.antlr:*:*</include>
                                         </includes>
                                     </artifactSet>
     

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -27,7 +27,6 @@
         <version>1.1.8-SNAPSHOT</version>
     </parent>
 
-    <groupId>ee.omnifish</groupId>
     <artifactId>jnosql-jakarta-persistence</artifactId>
     <packaging>jar</packaging>
 
@@ -64,8 +63,6 @@
                     <groupId>org.eclipse.jnosql.communication</groupId>
                     <artifactId>jnosql-communication-query</artifactId>
                 </exclusion>
-                <!-- <exclusion> <groupId>org.eclipse.jnosql.mapping</groupId> 
-                <artifactId>jnosql-mapping-reflection</artifactId> </exclusion> -->
             </exclusions>
         </dependency>
         <dependency>
@@ -162,13 +159,6 @@
         </dependency>
     </dependencies>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>dash-licenses-snapshots</id>
-            <url>https://repo.eclipse.org/content/groups/releases/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <build>
         <pluginManagement>
             <plugins>
@@ -187,242 +177,23 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
-                <executions>
-                    <execution>
-                        <id>enforce-maven</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>3.9.5</version>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
             <!-- Check licenses of dependencies -->
             <plugin>
                 <groupId>org.eclipse.dash</groupId>
                 <artifactId>license-tool-plugin</artifactId>
-                <version>1.1.0</version>
-                <executions>
-                    <execution>
-                        <id>license-check</id>
-                        <goals>
-                            <goal>license-check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <!-- Generate a "consumer pom" for the generated jar -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.7.0</version>
-                <configuration>
-                    <flattenMode>ossrh</flattenMode>
-                </configuration>
-                <executions>
-                    <!-- enable flattening -->
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                    <!-- ensure proper cleanup -->
-                    <execution>
-                        <id>flatten.clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
-    
-    <profiles>
-        <profile>
-            <id>shade</id>
-            
-            <properties>
-                <osgi.imports>!org.eclipse.jnosql.**, *</osgi.imports>
-                <osgi.exports>org.eclipse.jnosql.mapping, org.eclipse.jnosql.mapping.metadata</osgi.exports>
-            </properties>
-    
-            <build>
-                <plugins>
-                    <!-- Creates the OSGi MANIFEST.MF file -->
-                    <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
-                        <version>6.0.0</version>
-                        <configuration>
-                            <instructions>
-                                <_noimportjava>true</_noimportjava>
-                                <_runee>JavaSE-17</_runee>
-                                <!-- <Automatic-Module-Name>org.eclipse.jnosql.jakartapersistence</Automatic-Module-Name> -->
-                                <Extension-Name>org.eclipse.jnosql.jakartapersistence</Extension-Name>
-
-                                <Bundle-SymbolicName>org.eclipse.jnosql.jakartapersistence</Bundle-SymbolicName>
-                                <Bundle-Version>${project.version}</Bundle-Version>
-                                <Bundle-Name>Jakarta Data Implementation ${project.version}</Bundle-Name>
-                                <Bundle-Description>Eclipse Jakarta Data Implementation (jakarta.data/1.0) ${project.version}</Bundle-Description>
-
-                                <Specification-Title>Jakarta Data</Specification-Title>
-                                <Specification-Version>1.0</Specification-Version>
-                                <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
-
-                                <Implementation-Title>JNoSQL Jakarta Persistence</Implementation-Title>
-                                <Implementation-Version>${project.version}</Implementation-Version>
-                                <Implementation-Vendor>Eclipse</Implementation-Vendor>
-                                <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
-
-                                <Import-Package>
-                                    jakarta.enterprise.inject.spi.configurator, !org.antlr.*, ${osgi.imports}
-                                </Import-Package>
-                                <Embed-Dependency>org.antlr:*,
-                                                    org.eclipse.jnosql.mapping:*,
-                                                    org.eclipse.jnosql.communication:*,
-                                                    jakarta.nosql:*
-                                </Embed-Dependency>
-                                <Export-Package>
-                                    org.eclipse.jnosql.jakartapersistence.*, org.eclipse.jnosql.communication.*,
-                                    org.eclipse.jnosql.mapping.core.spi.*, org.eclipse.jnosql.mapping.document.*, 
-                                    org.eclipse.jnosql.mapping.core.*, ${osgi.exports}
-                                </Export-Package>
-                            </instructions>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>bundle-manifest</id>
-                                <phase>process-classes</phase>
-                                <goals>
-                                    <goal>manifest</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
-                    <plugin>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <version>3.4.2</version>
-                        <configuration>
-                            <archive>
-                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                            </archive>
-                        </configuration>
-                    </plugin>
-
-                    <plugin>
-                        <artifactId>maven-shade-plugin</artifactId>
-                        <version>3.6.0</version>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>shade</goal>
-                                </goals>
-                                <configuration>
-                                    <createDependencyReducedPom>true</createDependencyReducedPom>
-                                    <useDependencyReducedPomInJar>true</useDependencyReducedPomInJar>
-                                    <artifactSet>
-                                        <includes>
-                                            <!-- JNoSQL -->
-                                            <include>org.eclipse.jnosql.mapping:*:*</include>
-                                            <include>org.eclipse.jnosql.communication:*:*</include>
-                                            <include>jakarta.nosql:*:*</include>
-                                            <include>org.antlr:*:*</include>
-                                        </includes>
-                                    </artifactSet>
-    
-                                    <transformers>
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                    </transformers>
-    
-                                    <!-- Disable CDI extensions in JNoSQL except the Jakarta Persistence extension 
-                                         until we integrate them properly. Currently they conflict with the Jakarta Persistence extension 
-                                    -->
-                                    <filters>
-                                        <filter>
-                                            <artifact>org.eclipse.jnosql.mapping:jnosql-mapping-reflection</artifact>
-                                            <excludes>
-                                                <!-- Disable the default JNoSql ClassScanner to allow adding a custom one -->
-                                                <exclude>META-INF/services/org.eclipse.jnosql.mapping.metadata.ClassScanner</exclude>
-                                                <exclude>META-INF/services/jakarta.enterprise.inject.spi.Extension</exclude>
-                                            </excludes>
-                                        </filter>
-                                        <filter>
-                                            <artifact>org.eclipse.jnosql.mapping:jnosql-mapping-document</artifact>
-                                            <excludes>
-                                                <exclude>META-INF/services/jakarta.enterprise.inject.spi.Extension</exclude>
-                                            </excludes>
-                                        </filter>
-                                        <filter>
-                                            <artifact>org.eclipse.jnosql.mapping:jnosql-mapping-core</artifact>
-                                            <excludes>
-                                                <exclude>META-INF/services/jakarta.enterprise.inject.spi.Extension</exclude>
-                                            </excludes>
-                                        </filter>
-                                    </filters>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        
-        <profile>
-            <id>release</id>
-            
-            <properties>
-                <altDeploymentRepository>central::https://central.sonatype.com/repository/maven-snapshots</altDeploymentRepository>
-                <altSnapshotDeploymentRepository>central::https://central.sonatype.com/repository/maven-snapshots</altSnapshotDeploymentRepository>
-                <deploy.skip>false</deploy.skip>
-            </properties>
-            
-            <build>
-                <plugins>
-                    <!-- Signing with GPG is a requirement for a release deployment to Maven central. -->
-                    <plugin>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.4</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
-                        <extensions>false</extensions>
-                        <configuration>
-                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -300,7 +300,8 @@
                                 </Embed-Dependency>
                                 <Export-Package>
                                     org.eclipse.jnosql.jakartapersistence.*, org.eclipse.jnosql.communication.*,
-                                    org.eclipse.jnosql.mapping.core.spi.*, ${osgi.exports}
+                                    org.eclipse.jnosql.mapping.core.spi.*, org.eclipse.jnosql.mapping.document.*, 
+                                    org.eclipse.jnosql.mapping.core.*, ${osgi.exports}
                                 </Export-Package>
                             </instructions>
                         </configuration>
@@ -353,11 +354,28 @@
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
                                     </transformers>
     
+                                    <!-- Disable CDI extensions in JNoSQL except the Jakarta Persistence extension 
+                                         until we integrate them properly. Currently they conflict with the Jakarta Persistence extension 
+                                    -->
                                     <filters>
                                         <filter>
                                             <artifact>org.eclipse.jnosql.mapping:jnosql-mapping-reflection</artifact>
                                             <excludes>
+                                                <!-- Disable the default JNoSql ClassScanner to allow adding a custom one -->
                                                 <exclude>META-INF/services/org.eclipse.jnosql.mapping.metadata.ClassScanner</exclude>
+                                                <exclude>META-INF/services/jakarta.enterprise.inject.spi.Extension</exclude>
+                                            </excludes>
+                                        </filter>
+                                        <filter>
+                                            <artifact>org.eclipse.jnosql.mapping:jnosql-mapping-document</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/services/jakarta.enterprise.inject.spi.Extension</exclude>
+                                            </excludes>
+                                        </filter>
+                                        <filter>
+                                            <artifact>org.eclipse.jnosql.mapping:jnosql-mapping-core</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/services/jakarta.enterprise.inject.spi.Extension</exclude>
                                             </excludes>
                                         </filter>
                                     </filters>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
@@ -17,9 +17,6 @@ package org.eclipse.jnosql.jakartapersistence.communication;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Root;
 import jakarta.persistence.metamodel.EntityType;
 
 import java.util.HashMap;
@@ -32,16 +29,13 @@ public class PersistenceDatabaseManager {
 
     private final Map<String, EntityType<?>> entityTypesByName = new HashMap<>();
 
-    record QueryContext<FROM, RESULT>(CriteriaQuery<RESULT> query, Root<FROM> root, CriteriaBuilder builder) {
-    }
-
     @Inject
     public PersistenceDatabaseManager(EntityManager em) {
         this.em = em;
         cacheEntityTypes();
     }
 
-    PersistenceDatabaseManager() {
+    public PersistenceDatabaseManager() {
         em = null;
     }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
@@ -67,14 +67,14 @@ public class PersistenceDocumentTemplate implements DocumentTemplate {
     private final UpdateQueryParser updateParser;
 
     @Inject
-    PersistenceDocumentTemplate(PersistenceDatabaseManager manager) {
+    public PersistenceDocumentTemplate(PersistenceDatabaseManager manager) {
         this.manager = manager;
         this.selectParser = new SelectQueryParser(manager);
         this.deleteParser = new DeleteQueryParser(manager);
         this.updateParser = new UpdateQueryParser(manager);
     }
 
-    PersistenceDocumentTemplate() {
+    public PersistenceDocumentTemplate() {
         manager = null;
         selectParser = null;
         deleteParser = null;

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
@@ -106,7 +106,9 @@ public class JakartaPersistenceRepositoryProxy<T, K> extends AbstractSemiStructu
     }
 
     @SuppressWarnings("unchecked")
-    protected Object executeFindByQuery(Method method, Object[] args, Class<?> typeClass, org.eclipse.jnosql.communication.semistructured.SelectQuery query) {
+    protected Object executeFindByQuery(Method method, Object[] args, Class<?> typeClass, SelectQuery query) {
+        // TODO: Perform type check on return type during deployment and fail deployment if not supported.
+        // Currently, different types are supported by implementations of RepositoryReturn via service loader
         DynamicReturn<?> dynamicReturn = DynamicReturn.builder()
                 .classSource(typeClass)
                 .methodSource(method)

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/JakartaPersistenceExtension.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/JakartaPersistenceExtension.java
@@ -14,10 +14,7 @@
  */
 package org.eclipse.jnosql.jakartapersistence.mapping.spi;
 
-
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
 
@@ -28,7 +25,6 @@ import java.util.logging.Logger;
 
 import org.eclipse.jnosql.jakartapersistence.mapping.repository.CustomRepositoryPersistenceBean;
 import org.eclipse.jnosql.jakartapersistence.mapping.repository.RepositoryPersistenceBean;
-import org.eclipse.jnosql.mapping.core.spi.AbstractBean;
 
 /**
  * This CDI extension, {@code JakartaPersistenceExtension}, observes the CDI
@@ -67,13 +63,5 @@ public class JakartaPersistenceExtension implements Extension {
             afterBeanDiscovery.addBean(new CustomRepositoryPersistenceBean<>(type));
         });
 
-        afterBeanDiscovery.addBean()
-            .types(AbstractBean.class)
-            .scope(ApplicationScoped.class)
-            .qualifiers(Default.Literal.INSTANCE)
-            .createWith(ctx -> {
-                // This is just to define beanManager for AbstractBean, it shouldn't be injected
-                return null;
-            });
     }
 }

--- a/jnosql-jakarta-persistence/pom.xml
+++ b/jnosql-jakarta-persistence/pom.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~
-  ~  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
-  ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
-  ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
-  ~
-  ~   You may elect to redistribute this code under either of these licenses.
-  ~
-  ~   Contributors:
-  ~
-  ~   Ondro Mihalyi
-  ~
-  -->
+~
+~  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
+~   All rights reserved. This program and the accompanying materials
+~   are made available under the terms of the Eclipse Public License v1.0
+~   and Apache License v2.0 which accompanies this distribution.
+~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+~
+~   You may elect to redistribute this code under either of these licenses.
+~
+~   Contributors:
+~
+~   Ondro Mihalyi
+~
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,10 +32,98 @@
     <modules>
         <module>jnosql-jakarta-persistence-scanner</module>
         <module>jnosql-jakarta-persistence-driver</module>
+        <module>jnosql-jakarta-persistence-driver-osgi-bundle</module>
         <module>jnosql-jakarta-persistence-data-tck-runner</module>
     </modules>
 
     <properties>
         <eclipselink.version>5.0.0-B06</eclipselink.version>
     </properties>
+    
+    <pluginRepositories>
+        <pluginRepository>
+            <id>dash-licenses-snapshots</id>
+            <url>https://repo.eclipse.org/content/groups/releases/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.5.0</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-maven</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireMavenVersion>
+                                        <version>3.9.5</version>
+                                    </requireMavenVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- Check licenses of dependencies -->
+                <plugin>
+                    <groupId>org.eclipse.dash</groupId>
+                    <artifactId>license-tool-plugin</artifactId>
+                    <version>1.1.0</version>
+                    <executions>
+                        <execution>
+                            <id>license-check</id>
+                            <goals>
+                                <goal>license-check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- Generate a "consumer pom" for the generated jar -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.7.0</version>
+                    <configuration>
+                        <flattenMode>ossrh</flattenMode>
+                    </configuration>
+                    <executions>
+                        <!-- enable flattening -->
+                        <execution>
+                            <id>flatten</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                        </execution>
+                        <!-- ensure proper cleanup -->
+                        <execution>
+                            <id>flatten.clean</id>
+                            <phase>clean</phase>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+ 
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>6.0.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.4.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
These changes allow next step of integration of the Data impl into GlassFish.

Separates OSGi bundle into another Maven module, temporarily under the ee.omnifish coordinates to allow a quick release of a snapshot version to Maven Central.